### PR TITLE
Moved jquery back to external cdn libs

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -1,3 +1,2 @@
-script(src="https://code.jquery.com/jquery-1.12.4.min.js")
 script(src="/js/app.js")
 block foot

--- a/public/js/config/external_cdn_libs.json
+++ b/public/js/config/external_cdn_libs.json
@@ -1,4 +1,5 @@
 [
+	"https://code.jquery.com/jquery-1.12.4.min.js",
     "https://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.js",
 	"https://cdnjs.cloudflare.com/ajax/libs/jquery-tagsinput/1.3.6/jquery.tagsinput.min.js",
     "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js",


### PR DESCRIPTION
External cdn libs actually gets loaded before foot.jade, so this was the wrong file afterall. Changes to the libraries requires a nodejs restart to go live, which is why I initially didn't notice it actually wasn't working.